### PR TITLE
[FEAT] 웹소켓 요청 AuthInterceptor 제외

### DIFF
--- a/src/main/java/com/snowflakes/rednose/config/WebConfig.java
+++ b/src/main/java/com/snowflakes/rednose/config/WebConfig.java
@@ -37,6 +37,10 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(authInterceptor);
+        registry.addInterceptor(authInterceptor)
+                .excludePathPatterns(
+                        "/stamp-craft/**",
+                        "/sub/stamp-craft/**"
+                );
     }
 }


### PR DESCRIPTION
## #64 

### 💡 PR 타입(하나 이상의 PR 타입을 선택해주세요)
* [ ] 기능 추가
* [ ] 기능 삭제
* [ ] 리팩터링
* [x] 버그 수정
* [ ] 테스트코드 작성
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📲 반영 브랜치
64/feat-excludestampapi -> develop

### ❔ 변경 사항
웹소켓 요청 AuthInterceptor 제외
```java
    @MessageMapping("/stamp-craft/{stamp-craft-id}/enter")
    @SendTo("/sub/stamp-craft/{stamp-craft-id}")
    public EnterStampCraftResponse enter(@DestinationVariable("stamp-craft-id") Long stampCraftId,
                                         SimpMessageHeaderAccessor accessor) {
        return stampCraftService.enter(stampCraftId, accessor);
    }

    @MessageMapping("/stamp-craft/{stamp-craft-id}/paint")
    @SendTo("/sub/stamp-craft/{stamp-craft-id}")
    public PaintStampResponse paint(@DestinationVariable("stamp-craft-id") Long stampCraftId,
                                    @RequestBody PaintStampRequest request) {
        return stampCraftService.paint(stampCraftId, request);
    }

    @MessageMapping("/stamp-craft/{stamp-craft-id}/leave")
    @SendTo("/sub/stamp-craft/{stamp-craft-id}")
    public LeaveStampCraftResponse leave(@DestinationVariable("stamp-craft-id") Long stampCraftId,
                                         SimpMessageHeaderAccessor accessor) {
        return stampCraftService.leave(stampCraftId, accessor);
    }
```
위 3개에 대해 공통적으로 포함할 수 있게 작성함

웹소켓 관련이라 테스트 불가하므로 맞게 추가했는지 확인바람
